### PR TITLE
fix(ci): use full git history on PRs and fail loudly on diff errors

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -18,8 +18,14 @@ jobs:
     steps:
       - uses: actions/checkout@v4
         with:
-          # PRs need full history to diff against the base branch.
-          fetch-depth: ${{ github.event_name == 'pull_request' && 0 || 1 }}
+          # Always full history. We previously tried
+          #   fetch-depth: ${{ github.event_name == 'pull_request' && 0 || 1 }}
+          # to avoid the cost on main pushes, but GitHub Actions evaluates that
+          # expression to `1` even on PRs (the `&& 0 || 1` ternary trap — 0 is
+          # falsy in Actions expressions, so `0 || 1` short-circuits to 1). That
+          # left PR checkouts shallow, `git diff $base HEAD` failed with
+          # "fatal: bad object", and the matrix silently went empty.
+          fetch-depth: 0
 
       - id: detect
         name: Determine which demos to build
@@ -33,7 +39,15 @@ jobs:
           if [ "${{ github.event_name }}" = "pull_request" ]; then
             # Build only demos whose files changed in this PR.
             base="${{ github.event.pull_request.base.sha }}"
-            mapfile -t changed_files < <(git diff --name-only "$base" HEAD)
+            # Run git diff in two stages so we fail loudly on errors. The previous
+            # version used `mapfile < <(git diff ...)`, but process substitution
+            # hides the subshell's exit status from `set -e`, so a bad-object
+            # error produced an empty array and a silently-skipped build.
+            if ! changed_output="$(git diff --name-only "$base" HEAD)"; then
+              echo "::error::git diff against base $base failed (likely a shallow checkout — confirm fetch-depth: 0 on the checkout step)"
+              exit 1
+            fi
+            mapfile -t changed_files <<< "$changed_output"
             demos_to_build=()
             for d in "${all_demos[@]}"; do
               for f in "${changed_files[@]}"; do


### PR DESCRIPTION
## Summary

Two bugs in the CI workflow from #1 made path-filtered builds silently skip on every PR. Discovered while opening #2 — the matrix went empty and the build job was reported as "skipping" even though \`easy-paging-demo/\` was clearly the changed directory.

## Two bugs, one symptom

### Bug 1 — GitHub Actions ternary trap on \`fetch-depth\`

\`\`\`yaml
fetch-depth: \${{ github.event_name == 'pull_request' && 0 || 1 }}
\`\`\`

The intent was "0 (full history) on PRs, 1 (shallow) otherwise". But in Actions expressions, **\`0\` is falsy**, so \`0 || 1\` short-circuits to \`1\`. The expression evaluates to \`1\` on **both** PRs and main pushes. PR checkouts had no history beyond the merge commit.

### Bug 2 — silent failure on \`git diff\`

\`\`\`bash
mapfile -t changed_files < <(git diff --name-only "\$base" HEAD)
\`\`\`

With bug 1 in effect, \`git diff\` exited with \`fatal: bad object\` because the base SHA was never fetched. But **process substitution does not propagate the subshell's exit status under \`set -e\`** — so the script kept going with an empty \`changed_files\` array. The matrix went empty. The build job was marked as "skipping". CI looked green but had built nothing.

## Fix

- **\`fetch-depth: 0\` unconditionally.** Cost is negligible for this repo and removes the ternary footgun entirely. A code comment now flags the trap so the next person doesn't reintroduce it.
- **Two-stage \`git diff\`** with explicit error check, so \`set -e\` actually catches a non-zero exit. \`::error::\` annotation points at the likely cause (shallow checkout) for the next debugger.

## Verification

Will be confirmed when #2 is rebased on top of this fix:
- On that PR's CI run, the \`detect\` job should output \`demos: ["easy-paging-demo"]\` and \`any: true\`.
- The \`build (easy-paging-demo)\` matrix job should actually run \`./gradlew build\` rather than skipping.

Cannot be verified by this PR's own CI run — this PR doesn't touch any demo directory, so the matrix will (correctly) be empty and \`build\` will (correctly) skip. The fix only takes effect when there's a demo change to detect.

## Test plan

- [ ] CI on this PR: \`detect\` job passes (with the new defensive diff handling), \`build\` skipped (no demos changed — expected)
- [ ] After merge + rebase of #2: \`detect\` job emits \`easy-paging-demo\` in the matrix, \`build\` job runs end-to-end and turns green