### PR TITLE
ci: add Dependabot config for all demos + CI workflows

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,82 @@
+# Keeps every standalone Gradle demo in this repo up to date with the
+# Spring Boot ecosystem and the devslab-kr starters they showcase.
+#
+# Each demo is an independent Gradle project (its own settings.gradle.kts and
+# wrapper), so Dependabot needs to be told about each directory explicitly.
+# We use `directories:` (plural) so one ecosystem entry covers them all
+# with a shared group/schedule/label policy — much less duplication than
+# nine near-identical entries.
+
+version: 2
+
+updates:
+  # ---------------------------------------------------------------------
+  # Gradle: every demo + the starter ecosystems they depend on.
+  # ---------------------------------------------------------------------
+  - package-ecosystem: "gradle"
+    directories:
+      - "/easy-paging-demo"
+      - "/easy-paging-keyset-demo"
+      - "/easy-paging-postgres-demo"
+      - "/easy-paging-reactive-demo"
+      - "/ssrf-guard-demo"
+      - "/ssrf-guard-springai-demo"
+      - "/ssrf-guard-feign-demo"
+      - "/ssrf-guard-jdkhttp-demo"
+      - "/ssrf-guard-okhttp-demo"
+    schedule:
+      interval: "weekly"
+      day: "monday"
+      time: "09:00"
+      timezone: "Asia/Seoul"
+    open-pull-requests-limit: 10
+    labels:
+      - "dependencies"
+    commit-message:
+      prefix: "build(deps)"
+      include: "scope"
+    # Group related bumps into single PRs to keep the queue manageable.
+    groups:
+      # devslab-kr starters this repo exists to showcase — every new release
+      # should produce one tight PR per demo, not N PRs across submodules.
+      easy-paging:
+        patterns:
+          - "kr.devslab:easy-paging*"
+      ssrf-guard:
+        patterns:
+          - "kr.devslab:ssrf-guard*"
+      # Spring Boot moves as a unit; bump everything together or nothing.
+      spring-boot:
+        patterns:
+          - "org.springframework.boot:*"
+          - "io.spring.dependency-management"
+      # Test deps — none of these affect runtime behaviour, batch them.
+      test-tooling:
+        patterns:
+          - "org.testcontainers:*"
+          - "org.springframework.boot:spring-boot-testcontainers"
+          - "io.projectreactor:reactor-test"
+          - "org.junit*:*"
+      # Database drivers — usually bumped together when Spring Boot moves.
+      database-drivers:
+        patterns:
+          - "org.postgresql:*"
+          - "com.h2database:h2"
+          - "io.r2dbc:*"
+
+  # ---------------------------------------------------------------------
+  # GitHub Actions workflows used by the CI in .github/workflows.
+  # ---------------------------------------------------------------------
+  - package-ecosystem: "github-actions"
+    directory: "/"
+    schedule:
+      interval: "weekly"
+      day: "monday"
+      time: "09:00"
+      timezone: "Asia/Seoul"
+    labels:
+      - "dependencies"
+      - "github-actions"
+    commit-message:
+      prefix: "build(ci)"
+      include: "scope"


### PR DESCRIPTION
## Summary

Each demo README in this repo says "Dependabot bumps it on new releases" — but there was no \`dependabot.yml\` actually backing that claim. This PR adds it.

## What it watches

**Gradle** (single ecosystem entry, \`directories:\` plural — covers all 9 demos):
- \`/easy-paging-demo\`, \`/easy-paging-keyset-demo\`, \`/easy-paging-postgres-demo\`, \`/easy-paging-reactive-demo\`
- \`/ssrf-guard-demo\`, \`/ssrf-guard-springai-demo\`, \`/ssrf-guard-feign-demo\`, \`/ssrf-guard-jdkhttp-demo\`, \`/ssrf-guard-okhttp-demo\`

**GitHub Actions** workflows in \`.github/workflows/\`.

## Grouping strategy

Related bumps get collapsed into single PRs so the queue stays manageable as demos grow:

| Group | Patterns | Why grouped |
| --- | --- | --- |
| \`easy-paging\` | \`kr.devslab:easy-paging*\` | One starter release ⇒ one PR per demo, not N |
| \`ssrf-guard\` | \`kr.devslab:ssrf-guard*\` | Same |
| \`spring-boot\` | \`org.springframework.boot:*\` + \`io.spring.dependency-management\` | Spring Boot moves as a unit; partial bumps break |
| \`test-tooling\` | \`org.testcontainers:*\`, \`spring-boot-testcontainers\`, \`reactor-test\`, \`org.junit*:*\` | None affect runtime; batch them |
| \`database-drivers\` | \`org.postgresql:*\`, \`com.h2database:h2\`, \`io.r2dbc:*\` | Usually bumped together with Spring Boot |

## Schedule

Weekly, Monday 09:00 KST. PR cap of 10 open at once.

## Verification

This is a config-only change, no code or build script touched. CI \`detect\` job should identify zero demos changed (\`.github/dependabot.yml\` doesn't match any \`*-demo/\` path), build job correctly skipped — that mirrors what PR #3 looked like.

## Test plan

- [ ] CI green (detect → no demos → build skipped, all checks pass)
- [ ] After merge, the GitHub UI \`Insights → Dependency graph → Dependabot\` page shows the schedule registered for all 9 directories + the github-actions ecosystem
- [ ] On the next starter release (or next Monday), a grouped \`build(deps)\` PR appears with the right scope label