### PR TITLE
fix(deps): hold Spring Boot/Framework/Gradle majors until starter certifies

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -35,6 +35,39 @@ updates:
     commit-message:
       prefix: "build(deps)"
       include: "scope"
+    # ----------------------------------------------------------------
+    # Hold majors at the starter's tested baseline.
+    #
+    # The demos exist to showcase the starters at the Spring Boot
+    # version each starter is *certified against* (per its README).
+    # Letting Dependabot land a Spring Boot major (3.x → 4.x) ahead of
+    # the starter's own SB4 release would silently advertise
+    # incompatible combinations to anyone copying a demo.
+    #
+    # When a starter publishes a SB4-compatible release line (e.g.
+    # easy-paging 0.5.x), this ignore block gets relaxed for that
+    # specific starter family, and the demos are upgraded together in
+    # a single PR — not piecemeal by a robot.
+    # ----------------------------------------------------------------
+    ignore:
+      # Spring Boot + dependency-management major bumps
+      - dependency-name: "org.springframework.boot:*"
+        update-types: ["version-update:semver-major"]
+      - dependency-name: "io.spring.dependency-management"
+        update-types: ["version-update:semver-major"]
+      # Spring Framework / Spring Cloud — pulled in transitively by SB,
+      # but their majors land outside the SB BOM cadence sometimes
+      - dependency-name: "org.springframework:*"
+        update-types: ["version-update:semver-major"]
+      - dependency-name: "org.springframework.cloud:*"
+        update-types: ["version-update:semver-major"]
+      # Gradle wrapper — each new major (8 → 9, etc.) needs hand
+      # verification (deprecations may have become errors). Dependabot
+      # bumps the *wrapper version*, which doesn't run any code; the
+      # CI catches breakage on next build, but a major bump deserves
+      # a dedicated PR with eyes on it, not 9 silent ones.
+      - dependency-name: "gradle"
+        update-types: ["version-update:semver-major"]
     # Group related bumps into single PRs to keep the queue manageable.
     groups:
       # devslab-kr starters this repo exists to showcase — every new release


### PR DESCRIPTION
## Summary

Dependabot opened 18 individual PRs (#19-#36) to bump every demo from Spring Boot **3.5.3 → 4.0.6** (major) and Gradle wrapper **8.10.2 → 9.5.1** (major). The grouped PRs from the same run worked fine (e.g. #18 spring-boot patch/minor across 9 dirs); what didn't was that **Dependabot's default group semantics exclude \`version-update:semver-major\`**, so majors escaped grouping and landed as individual PRs per demo.

Beyond the queue noise, the **real problem** is that the demos must mirror the Spring Boot baseline each *starter* was certified against — per the easy-paging README:

> Spring Boot 3.3+ on Java 21+ (built/tested against 3.5)

\`easy-paging-spring-boot-starter\` has not (yet) published a release certified against Spring Boot 4 / Spring Framework 7 / Jakarta EE 11. Auto-bumping demos to SB4 would silently advertise an unverified combination to anyone who clones a demo as a starting point.

## Change

Adds an \`ignore\` block holding majors for:

| Pattern | Why hold |
| --- | --- |
| \`org.springframework.boot:*\` | The BOM driver — moving it majors everything |
| \`io.spring.dependency-management\` | Coupled to SB plugin |
| \`org.springframework:*\` | Transitively pulled in; majors can land off the SB cadence |
| \`org.springframework.cloud:*\` | Same |
| \`gradle\` (wrapper) | Each major needs hand verification of deprecations-now-errors before going green across 9 demos |

Patch/minor bumps still flow through (and group correctly — PR #18 already proved that path), so security fixes within the 3.5.x line land normally.

## When to lift

When each starter publishes a SB4-compatible release line (e.g. \`easy-paging-spring-boot-starter:0.5.0\`), this ignore block gets relaxed for that specific starter family, and the demos get upgraded together in one intentional PR per starter — not piecemeal by a robot.

## Follow-up cleanup (manual, after this merges)

- ✅ Merge PR #18 (grouped patch/minor across 9 demos) — already proven correct group path
- ✅ Merge PRs #14-#17 (github-actions minors) — inside policy
- ❌ Close PRs #19-#36 (18 stragglers) — the new policy guarantees they won't reappear on the next Dependabot run

## Verification

Config-only change. CI \`detect\` job should identify zero demos changed (no \`*-demo/\` paths touched), build job correctly skipped.

YAML parse + structure check passed locally:
- 9 directories preserved
- 5 ignore rules (the new block)
- 5 groups preserved (easy-paging, ssrf-guard, spring-boot, test-tooling, database-drivers)

## Test plan

- [ ] CI green (detect → no demos → build skipped)
- [ ] After merge, follow up with the 4 merges + 18 closes listed above
- [ ] Next weekly Dependabot run (next Monday 09:00 KST) does NOT re-open any SB-major or Gradle-major PRs