### PR TITLE
fix(deps): hold kr.devslab starter majors on the SB3 demos line

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -56,6 +56,23 @@ updates:
         update-types: ["version-update:semver-major"]
       - dependency-name: "gradle"
         update-types: ["version-update:semver-major"]
+      # The starter family itself ships separate release lines for SB3
+      # (0.4.x) and SB4 (0.5.x+). A major bump of the easy-paging
+      # starter here would carry the SB3 demos into SB4 territory and
+      # break them (PR #40 was the first time we saw this in the wild
+      # — dependabot bumped to 0.5.0 across the SB3 demos and CI went
+      # red on all 4). Hold easy-paging majors so the SB3 demos stay
+      # on the 0.4.x line that matches their Spring Boot pin.
+      - dependency-name: "kr.devslab:easy-paging-spring-boot-starter"
+        update-types: ["version-update:semver-major"]
+      - dependency-name: "kr.devslab:easy-paging-spring-boot-starter-reactive"
+        update-types: ["version-update:semver-major"]
+      # Same shape applies to ssrf-guard's hypothetical SB4-only major
+      # release, if/when it ships — guard against it in advance.
+      - dependency-name: "kr.devslab:ssrf-guard"
+        update-types: ["version-update:semver-major"]
+      - dependency-name: "kr.devslab:ssrf-guard-*"
+        update-types: ["version-update:semver-major"]
     groups:
       easy-paging:
         patterns:


### PR DESCRIPTION
Quick policy fix surfaced by #40 (closed). The SB3 demos' `ignore` block held Spring Boot majors but didn't hold `kr.devslab` starter majors — so when easy-paging 0.5.0 (the SB4 release line) landed on Maven Central, Dependabot bumped the SB3 demos to it across all 4 directories and CI went red on all 4.

Adds these ignore rules to the SB3 demos entry:

- `kr.devslab:easy-paging-spring-boot-starter` (major hold)
- `kr.devslab:easy-paging-spring-boot-starter-reactive` (major hold)
- `kr.devslab:ssrf-guard` (preemptive)
- `kr.devslab:ssrf-guard-*` (preemptive)

Patch/minor still flows through grouped PRs as before. The SB4 demos entry is intentionally NOT touched — that's where these starters' SB4 majors should land.

Docs-only/config-only change.