### PR TITLE
fix(deps): stop double-deps in dependabot commit messages

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -43,7 +43,7 @@ updates:
       - "dependencies"
       - "sb3"
     commit-message:
-      prefix: "build(deps)"
+      prefix: "build"
       include: "scope"
     ignore:
       - dependency-name: "org.springframework.boot:*"
@@ -121,7 +121,7 @@ updates:
       - "dependencies"
       - "sb4"
     commit-message:
-      prefix: "build(deps)"
+      prefix: "build"
       include: "scope"
     # Still hold the Gradle wrapper major — has nothing to do with SB,
     # and a wrapper major needs hand verification regardless of line.
@@ -162,5 +162,5 @@ updates:
       - "dependencies"
       - "github-actions"
     commit-message:
-      prefix: "build(ci)"
+      prefix: "ci"
       include: "scope"


### PR DESCRIPTION
Quick fix for the `build(deps)(deps): ...` (and `build(ci)(deps): ...`) double-scope titles dependabot was producing.

## Root cause

```yaml
commit-message:
  prefix: "build(deps)"  # scope inlined here
  include: "scope"       # dependabot also inserts "(deps)" between prefix and ":"
```

Dependabot composes `<prefix><scope>: <message>` → `"build(deps)" + "(deps)" + ":" + ...` → doubled.

## Fix

Keep `include: "scope"` (the part that varies per dep / group / ecosystem and is genuinely useful), trim `prefix` to just the conventional-commit type:

| Ecosystem | prefix before | prefix after | Example PR title |
| --- | --- | --- | --- |
| Gradle (SB3 entry) | `build(deps)` | **`build`** | `build(deps): bump foo from 1 to 2` |
| Gradle (SB4 entry) | `build(deps)` | **`build`** | `build(deps): bump the spring-boot group ...` |
| github-actions | `build(ci)` | **`ci`** | `ci(deps): bump actions/checkout from 5 to 6` |

## Verification

Config-only. CI `detect` will identify zero demos changed (no `*-demo/` paths touched) and build job will skip.

## Test plan

- [ ] CI green
- [ ] Next Monday's dependabot run produces clean titles