### PR TITLE
build(deps): hold easy-paging at < 0.5 in the SB3 demo block

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -63,10 +63,16 @@ updates:
       # — dependabot bumped to 0.5.0 across the SB3 demos and CI went
       # red on all 4). Hold easy-paging majors so the SB3 demos stay
       # on the 0.4.x line that matches their Spring Boot pin.
+      #
+      # Because the starter is pre-1.0, 0.4 → 0.5 reads to Dependabot
+      # as a *minor* bump but is actually the SB3 → SB4 release-line
+      # jump. The semver-major ignore alone isn't enough — PR #50
+      # (2026-05-23) snuck through it. Pin "< 0.5" explicitly via the
+      # versions: filter so 0.4.x patches still flow but 0.5+ doesn't.
       - dependency-name: "kr.devslab:easy-paging-spring-boot-starter"
-        update-types: ["version-update:semver-major"]
+        versions: [">= 0.5"]
       - dependency-name: "kr.devslab:easy-paging-spring-boot-starter-reactive"
-        update-types: ["version-update:semver-major"]
+        versions: [">= 0.5"]
       # Same shape applies to ssrf-guard's hypothetical SB4-only major
       # release, if/when it ships — guard against it in advance.
       - dependency-name: "kr.devslab:ssrf-guard"


### PR DESCRIPTION
## Summary

Stops Dependabot from bumping `kr.devslab:easy-paging-spring-boot-starter` past 0.4.x in the four SB3 demos (`easy-paging-demo`, `easy-paging-keyset-demo`, `easy-paging-postgres-demo`, `easy-paging-reactive-demo`).

## Problem

Dependabot opened #50 bumping easy-paging 0.4.0 → 0.5.0 in the SB3 demos. CI went red on all four — 0.5.0 is the SB4 release line (Spring Framework 7 / Jackson 3) and the SB3 demos pin Spring Boot 3.5.x.

The existing ignore rule

```yaml
- dependency-name: "kr.devslab:easy-paging-spring-boot-starter"
  update-types: ["version-update:semver-major"]
```

didn't catch it because the starter is pre-1.0: `0.4 → 0.5` reads to Dependabot as a *minor* bump even though it's effectively the SB3 → SB4 release-line jump in this codebase.

## Fix

Replace the major-only ignore with an explicit `versions:` filter on both easy-paging artifacts:

```yaml
- dependency-name: "kr.devslab:easy-paging-spring-boot-starter"
  versions: [">= 0.5"]
- dependency-name: "kr.devslab:easy-paging-spring-boot-starter-reactive"
  versions: [">= 0.5"]
```

- 0.4.x patches still flow to the SB3 demos
- 0.5+ stays blocked
- The SB4 demos under `/easy-paging-sb4-*/` have no such ignore and continue to track the 0.5.x line

## Follow-up

After this merges, close #50 (PR will be a no-op against the new policy anyway, since Dependabot won't reopen).

## Test plan

- [ ] CI passes on this PR (only `.github/dependabot.yml` touched — no demo builds triggered)
- [ ] After merge, manual sanity check: Dependabot run does not reopen the 0.5.0 bump for SB3 demos