### PR TITLE
docs(readmes): fix stale version refs in SB4 demo + ssrf-guard KO READMEs

### DIFF
--- a/easy-paging-sb4-demo/README.ko.md
+++ b/easy-paging-sb4-demo/README.ko.md
@@ -73,7 +73,7 @@ curl 'http://localhost:8080/reports?page=999&size=20' | jq '.page, .empty'
 
 | 파일 | 왜 |
 | --- | --- |
-| `build.gradle.kts` | `spring-boot-starter-web` 외 추가하는 의존성은 `kr.devslab:easy-paging-spring-boot-starter:0.4.0` 하나뿐 |
+| `build.gradle.kts` | `spring-boot-starter-web` 외 추가하는 의존성은 `kr.devslab:easy-paging-spring-boot-starter:0.5.0` 하나뿐 |
 | `report/ReportController.java` | 전체 페이지네이션 계약은 `@AutoPaginate(maxSize = 50)` 어노테이션 + `PageResponse<Report>` 반환 타입 |
 | `report/ReportMapper.java` + `resources/mapper/ReportMapper.xml` | 평범한 `SELECT` — `LIMIT`, `OFFSET`, `COUNT` 모두 없음. 런타임에 aspect가 주입 |
 | `resources/application.yml` | `easy-paging` 전역 cap + 기본값 |

--- a/easy-paging-sb4-demo/README.md
+++ b/easy-paging-sb4-demo/README.md
@@ -73,7 +73,7 @@ The interesting parts, in order:
 
 | File | Why |
 | --- | --- |
-| `build.gradle.kts` | the only dependency the demo adds beyond `spring-boot-starter-web` is `kr.devslab:easy-paging-spring-boot-starter:0.4.0` |
+| `build.gradle.kts` | the only dependency the demo adds beyond `spring-boot-starter-web` is `kr.devslab:easy-paging-spring-boot-starter:0.5.0` |
 | `report/ReportController.java` | the entire pagination contract is the `@AutoPaginate(maxSize = 50)` annotation and the `PageResponse<Report>` return type |
 | `report/ReportMapper.java` + `resources/mapper/ReportMapper.xml` | plain `SELECT` — no `LIMIT`, no `OFFSET`, no `COUNT`. The aspect injects all of that at runtime |
 | `resources/application.yml` | `easy-paging` global caps and defaults |

--- a/easy-paging-sb4-keyset-demo/README.ko.md
+++ b/easy-paging-sb4-keyset-demo/README.ko.md
@@ -89,7 +89,7 @@ EASY_PAGING_CURSOR_SECRET='a-long-random-string-from-your-secrets-manager' ./gra
 
 | 파일 | 왜 |
 | --- | --- |
-| `build.gradle.kts` | `spring-boot-starter-web` 외 추가 의존성은 `kr.devslab:easy-paging-spring-boot-starter:0.4.0` (offset 데모와 동일) |
+| `build.gradle.kts` | `spring-boot-starter-web` 외 추가 의존성은 `kr.devslab:easy-paging-spring-boot-starter:0.5.0` (offset 데모와 동일) |
 | `location/LocationController.java` | 계약: `@KeysetPaginate(keys = {"time", "id"}, ...)` + 스타터가 자동 resolve하는 `KeysetRequest` 파라미터 |
 | `location/LocationService.java` | **size + 1** 트릭 (매퍼가 한 행 더 가져와서 `KeysetPage.build`가 `hasNext`를 정확히 설정) + 다음 커서가 되는 `keyExtractor` 람다 |
 | `location/LocationMapper.java` + `resources/mapper/LocationMapper.xml` | 복합 키 seek predicate — `time < ? OR (time = ? AND id < ?)`. 타임스탬프가 겹쳐도 walk를 안정적으로 만드는 핵심 |

--- a/easy-paging-sb4-keyset-demo/README.md
+++ b/easy-paging-sb4-keyset-demo/README.md
@@ -89,7 +89,7 @@ Signed cursors look the same in normal use, but become `<payload>.<hmac>` and an
 
 | File | Why |
 | --- | --- |
-| `build.gradle.kts` | the only dependency added beyond `spring-boot-starter-web` is `kr.devslab:easy-paging-spring-boot-starter:0.4.0` (same as the offset demo) |
+| `build.gradle.kts` | the only dependency added beyond `spring-boot-starter-web` is `kr.devslab:easy-paging-spring-boot-starter:0.5.0` (same as the offset demo) |
 | `location/LocationController.java` | the contract: `@KeysetPaginate(keys = {"time", "id"}, ...)` plus a `KeysetRequest` parameter resolved automatically by the starter |
 | `location/LocationService.java` | shows the **size + 1** trick (mapper fetches one extra row so `KeysetPage.build` can set `hasNext` correctly) and the `keyExtractor` lambda that becomes the next cursor |
 | `location/LocationMapper.java` + `resources/mapper/LocationMapper.xml` | the composite-key seek predicate — `time < ? OR (time = ? AND id < ?)` is what makes the walk stable when timestamps collide |

--- a/ssrf-guard-demo/README.ko.md
+++ b/ssrf-guard-demo/README.ko.md
@@ -124,7 +124,7 @@ curl -s http://localhost:8080/actuator/prometheus | grep ssrf_guard
 
 | 파일 | 왜 |
 | --- | --- |
-| `build.gradle.kts` | 표준 스타터 외 의존성은 `kr.devslab:ssrf-guard:3.1.0`, `:ssrf-guard-resttemplate:3.0.1`, `:ssrf-guard-webclient:3.0.1` 셋뿐 — 별도 configuration 클래스 불필요 |
+| `build.gradle.kts` | 표준 스타터 외 의존성은 `kr.devslab:ssrf-guard:3.1.0`, `:ssrf-guard-resttemplate:3.1.0`, `:ssrf-guard-webclient:3.1.0` 셋뿐 — 별도 configuration 클래스 불필요 |
 | `application.yml` | 모든 `ssrf.guard.*` 옵션이 한 곳에 주석과 함께 |
 | `web/FetchController.java` | RestClient 전체 — 3줄 setup, 가드는 보이지 않게 실행 |
 | `web/FetchResttemplateController.java` | RestTemplate 동일 — 레거시 코드 마이그레이션 불필요 |


### PR DESCRIPTION
## Summary

Five spots where the README prose lagged behind the actual `build.gradle.kts` pin:

| Demo | File | Line | Was | Now |
|---|---|---|---|---|
| easy-paging-sb4-demo | `README.md` | 76 | `:0.4.0` | `:0.5.0` |
| easy-paging-sb4-demo | `README.ko.md` | 76 | `:0.4.0` | `:0.5.0` |
| easy-paging-sb4-keyset-demo | `README.md` | 92 | `:0.4.0` | `:0.5.0` |
| easy-paging-sb4-keyset-demo | `README.ko.md` | 92 | `:0.4.0` | `:0.5.0` |
| ssrf-guard-demo | `README.ko.md` | 127 | `resttemplate:3.0.1`, `webclient:3.0.1` | `:3.1.0`, `:3.1.0` |

## Root cause

**SB4 demos (4 files):** When PR #39 forked the SB4 demos from the SB3 originals, the build files and the `> ✨ Spring Boot 4 line. ... 0.5.x line` header callout were correctly retargeted to `0.5.0`, but the "Files of interest" detail table at the bottom of each README still said `0.4.0`. The English READMEs for the postgres/reactive demos don't repeat the version in prose, so only the 4 files above were affected.

**ssrf-guard (1 file):** PR #52 (`ssrf-guard 3.0.1 → 3.1.0 + langchain4j demo`) bumped the README header and the meta-artifact mention, and updated all three sub-artifact lines in the English README (line 128). The Korean equivalent on line 127 only got the first artifact bumped — the half-update slipped through review.

## Not changed (intentional)

All `:0.4.0` references in the SB3 demo READMEs (`easy-paging-demo`, `easy-paging-keyset-demo`, `easy-paging-postgres-demo`, `easy-paging-reactive-demo`) are correct — those demos pin to the `0.4.x` maintenance line on purpose, per the dual-line policy.

## Test plan

- [ ] CI green
- [ ] After merge, `grep -rn "easy-paging-spring-boot-starter:0.4.0" easy-paging-sb4-*/README*` returns nothing
- [ ] After merge, `grep -rn "ssrf-guard[a-z-]*:3.0" ssrf-guard-*/README*` returns nothing