### PR TITLE
docs(all demos): add "Get just this demo" — per-folder clone instructions

### DIFF
--- a/api-log-jpa-demo/README.ko.md
+++ b/api-log-jpa-demo/README.ko.md
@@ -16,6 +16,28 @@
 - **Docker** (Docker Desktop 또는 호환 런타임)
 - 그 외 없음. 로컬 Postgres 설치 불필요. psql 클라이언트 불필요.
 
+## 이 데모만 받기
+
+각 데모는 독립 Gradle 프로젝트라, `devslab-examples` 저장소 전체를 clone하지 않고
+이 폴더만 받을 수 있습니다.
+
+**git 사용 (sparse checkout):**
+
+```bash
+git clone --filter=blob:none --sparse https://github.com/devslab-kr/devslab-examples.git
+cd devslab-examples
+git sparse-checkout set api-log-jpa-demo
+cd api-log-jpa-demo
+```
+
+**git 없이 (폴더만):**
+
+```bash
+curl -sL https://github.com/devslab-kr/devslab-examples/archive/refs/heads/main.tar.gz \
+  | tar -xz --strip-components=2 devslab-examples-main/api-log-jpa-demo
+cd api-log-jpa-demo
+```
+
 ## 실행
 
 ```bash

--- a/api-log-jpa-demo/README.md
+++ b/api-log-jpa-demo/README.md
@@ -16,6 +16,28 @@ This demo is **self-contained** — the same Spring Boot app exposes both the up
 - **Docker** (Docker Desktop or any Docker-compatible runtime)
 - That's it. No local Postgres install. No psql client needed.
 
+## Get just this demo
+
+Each demo is a standalone Gradle project, so you can grab this one folder without
+cloning the whole `devslab-examples` repo.
+
+**With git (sparse checkout):**
+
+```bash
+git clone --filter=blob:none --sparse https://github.com/devslab-kr/devslab-examples.git
+cd devslab-examples
+git sparse-checkout set api-log-jpa-demo
+cd api-log-jpa-demo
+```
+
+**Without git (folder only):**
+
+```bash
+curl -sL https://github.com/devslab-kr/devslab-examples/archive/refs/heads/main.tar.gz \
+  | tar -xz --strip-components=2 devslab-examples-main/api-log-jpa-demo
+cd api-log-jpa-demo
+```
+
 ## Run
 
 ```bash

--- a/api-log-mybatis-demo/README.ko.md
+++ b/api-log-mybatis-demo/README.ko.md
@@ -18,6 +18,28 @@
 - JDK 21+
 - **Docker** (Docker Desktop 또는 호환 런타임)
 
+## 이 데모만 받기
+
+각 데모는 독립 Gradle 프로젝트라, `devslab-examples` 저장소 전체를 clone하지 않고
+이 폴더만 받을 수 있습니다.
+
+**git 사용 (sparse checkout):**
+
+```bash
+git clone --filter=blob:none --sparse https://github.com/devslab-kr/devslab-examples.git
+cd devslab-examples
+git sparse-checkout set api-log-mybatis-demo
+cd api-log-mybatis-demo
+```
+
+**git 없이 (폴더만):**
+
+```bash
+curl -sL https://github.com/devslab-kr/devslab-examples/archive/refs/heads/main.tar.gz \
+  | tar -xz --strip-components=2 devslab-examples-main/api-log-mybatis-demo
+cd api-log-mybatis-demo
+```
+
 ## 실행
 
 ```bash

--- a/api-log-mybatis-demo/README.md
+++ b/api-log-mybatis-demo/README.md
@@ -18,6 +18,28 @@ Runnable example for [`api-log`](https://github.com/devslab-kr/api-log) — even
 - JDK 21+
 - **Docker** (Docker Desktop or any Docker-compatible runtime)
 
+## Get just this demo
+
+Each demo is a standalone Gradle project, so you can grab this one folder without
+cloning the whole `devslab-examples` repo.
+
+**With git (sparse checkout):**
+
+```bash
+git clone --filter=blob:none --sparse https://github.com/devslab-kr/devslab-examples.git
+cd devslab-examples
+git sparse-checkout set api-log-mybatis-demo
+cd api-log-mybatis-demo
+```
+
+**Without git (folder only):**
+
+```bash
+curl -sL https://github.com/devslab-kr/devslab-examples/archive/refs/heads/main.tar.gz \
+  | tar -xz --strip-components=2 devslab-examples-main/api-log-mybatis-demo
+cd api-log-mybatis-demo
+```
+
 ## Run
 
 ```bash

--- a/api-log-r2dbc-demo/README.ko.md
+++ b/api-log-r2dbc-demo/README.ko.md
@@ -20,6 +20,28 @@
 - **Docker** (Docker Desktop 또는 호환 런타임)
 - 그 외 없음. 로컬 Postgres 설치 불필요. psql 클라이언트 불필요.
 
+## 이 데모만 받기
+
+각 데모는 독립 Gradle 프로젝트라, `devslab-examples` 저장소 전체를 clone하지 않고
+이 폴더만 받을 수 있습니다.
+
+**git 사용 (sparse checkout):**
+
+```bash
+git clone --filter=blob:none --sparse https://github.com/devslab-kr/devslab-examples.git
+cd devslab-examples
+git sparse-checkout set api-log-r2dbc-demo
+cd api-log-r2dbc-demo
+```
+
+**git 없이 (폴더만):**
+
+```bash
+curl -sL https://github.com/devslab-kr/devslab-examples/archive/refs/heads/main.tar.gz \
+  | tar -xz --strip-components=2 devslab-examples-main/api-log-r2dbc-demo
+cd api-log-r2dbc-demo
+```
+
 ## 빠른 시작
 
 ```bash

--- a/api-log-r2dbc-demo/README.md
+++ b/api-log-r2dbc-demo/README.md
@@ -20,6 +20,28 @@ Production-flavoured runnable example for [`api-log`](https://github.com/devslab
 - **Docker** (Docker Desktop or any Docker-compatible runtime)
 - That's it. No local Postgres install. No psql client needed.
 
+## Get just this demo
+
+Each demo is a standalone Gradle project, so you can grab this one folder without
+cloning the whole `devslab-examples` repo.
+
+**With git (sparse checkout):**
+
+```bash
+git clone --filter=blob:none --sparse https://github.com/devslab-kr/devslab-examples.git
+cd devslab-examples
+git sparse-checkout set api-log-r2dbc-demo
+cd api-log-r2dbc-demo
+```
+
+**Without git (folder only):**
+
+```bash
+curl -sL https://github.com/devslab-kr/devslab-examples/archive/refs/heads/main.tar.gz \
+  | tar -xz --strip-components=2 devslab-examples-main/api-log-r2dbc-demo
+cd api-log-r2dbc-demo
+```
+
 ## Quickstart
 
 ```bash

--- a/devslab-kit-demo/README.ko.md
+++ b/devslab-kit-demo/README.ko.md
@@ -20,6 +20,28 @@
 - Java 21+
 - Docker (Compose / Testcontainers로 PostgreSQL + Redis 기동)
 
+## 이 데모만 받기
+
+각 데모는 독립 Gradle 프로젝트라, `devslab-examples` 저장소 전체를 clone하지 않고
+이 폴더만 받을 수 있습니다.
+
+**git 사용 (sparse checkout):**
+
+```bash
+git clone --filter=blob:none --sparse https://github.com/devslab-kr/devslab-examples.git
+cd devslab-examples
+git sparse-checkout set devslab-kit-demo
+cd devslab-kit-demo
+```
+
+**git 없이 (폴더만):**
+
+```bash
+curl -sL https://github.com/devslab-kr/devslab-examples/archive/refs/heads/main.tar.gz \
+  | tar -xz --strip-components=2 devslab-examples-main/devslab-kit-demo
+cd devslab-kit-demo
+```
+
 ## 실행
 
 ```bash

--- a/devslab-kit-demo/README.md
+++ b/devslab-kit-demo/README.md
@@ -21,6 +21,28 @@ auto-configuration.
 - Java 21+
 - Docker (for PostgreSQL + Redis via Compose / Testcontainers)
 
+## Get just this demo
+
+Each demo is a standalone Gradle project, so you can grab this one folder without
+cloning the whole `devslab-examples` repo.
+
+**With git (sparse checkout):**
+
+```bash
+git clone --filter=blob:none --sparse https://github.com/devslab-kr/devslab-examples.git
+cd devslab-examples
+git sparse-checkout set devslab-kit-demo
+cd devslab-kit-demo
+```
+
+**Without git (folder only):**
+
+```bash
+curl -sL https://github.com/devslab-kr/devslab-examples/archive/refs/heads/main.tar.gz \
+  | tar -xz --strip-components=2 devslab-examples-main/devslab-kit-demo
+cd devslab-kit-demo
+```
+
 ## Run
 
 ```bash

--- a/easy-paging-demo/README.ko.md
+++ b/easy-paging-demo/README.ko.md
@@ -11,6 +11,28 @@
 - JDK 21+
 - 그 외 없음. H2는 인메모리, 의존성은 최초 빌드 시 다운로드됨.
 
+## 이 데모만 받기
+
+각 데모는 독립 Gradle 프로젝트라, `devslab-examples` 저장소 전체를 clone하지 않고
+이 폴더만 받을 수 있습니다.
+
+**git 사용 (sparse checkout):**
+
+```bash
+git clone --filter=blob:none --sparse https://github.com/devslab-kr/devslab-examples.git
+cd devslab-examples
+git sparse-checkout set easy-paging-demo
+cd easy-paging-demo
+```
+
+**git 없이 (폴더만):**
+
+```bash
+curl -sL https://github.com/devslab-kr/devslab-examples/archive/refs/heads/main.tar.gz \
+  | tar -xz --strip-components=2 devslab-examples-main/easy-paging-demo
+cd easy-paging-demo
+```
+
 ## 실행
 
 ```bash

--- a/easy-paging-demo/README.md
+++ b/easy-paging-demo/README.md
@@ -11,6 +11,28 @@ This demo wires the starter into a minimal Spring Boot app with an in-memory H2 
 - JDK 21+
 - Nothing else. H2 runs in-memory, dependencies download on first build.
 
+## Get just this demo
+
+Each demo is a standalone Gradle project, so you can grab this one folder without
+cloning the whole `devslab-examples` repo.
+
+**With git (sparse checkout):**
+
+```bash
+git clone --filter=blob:none --sparse https://github.com/devslab-kr/devslab-examples.git
+cd devslab-examples
+git sparse-checkout set easy-paging-demo
+cd easy-paging-demo
+```
+
+**Without git (folder only):**
+
+```bash
+curl -sL https://github.com/devslab-kr/devslab-examples/archive/refs/heads/main.tar.gz \
+  | tar -xz --strip-components=2 devslab-examples-main/easy-paging-demo
+cd easy-paging-demo
+```
+
 ## Run
 
 ```bash

--- a/easy-paging-keyset-demo/README.ko.md
+++ b/easy-paging-keyset-demo/README.ko.md
@@ -11,6 +11,28 @@
 - JDK 21+
 - 그 외 없음.
 
+## 이 데모만 받기
+
+각 데모는 독립 Gradle 프로젝트라, `devslab-examples` 저장소 전체를 clone하지 않고
+이 폴더만 받을 수 있습니다.
+
+**git 사용 (sparse checkout):**
+
+```bash
+git clone --filter=blob:none --sparse https://github.com/devslab-kr/devslab-examples.git
+cd devslab-examples
+git sparse-checkout set easy-paging-keyset-demo
+cd easy-paging-keyset-demo
+```
+
+**git 없이 (폴더만):**
+
+```bash
+curl -sL https://github.com/devslab-kr/devslab-examples/archive/refs/heads/main.tar.gz \
+  | tar -xz --strip-components=2 devslab-examples-main/easy-paging-keyset-demo
+cd easy-paging-keyset-demo
+```
+
 ## 실행
 
 ```bash

--- a/easy-paging-keyset-demo/README.md
+++ b/easy-paging-keyset-demo/README.md
@@ -11,6 +11,28 @@ Companion to [`easy-paging-demo`](../easy-paging-demo/) — which covers traditi
 - JDK 21+
 - Nothing else.
 
+## Get just this demo
+
+Each demo is a standalone Gradle project, so you can grab this one folder without
+cloning the whole `devslab-examples` repo.
+
+**With git (sparse checkout):**
+
+```bash
+git clone --filter=blob:none --sparse https://github.com/devslab-kr/devslab-examples.git
+cd devslab-examples
+git sparse-checkout set easy-paging-keyset-demo
+cd easy-paging-keyset-demo
+```
+
+**Without git (folder only):**
+
+```bash
+curl -sL https://github.com/devslab-kr/devslab-examples/archive/refs/heads/main.tar.gz \
+  | tar -xz --strip-components=2 devslab-examples-main/easy-paging-keyset-demo
+cd easy-paging-keyset-demo
+```
+
 ## Run
 
 ```bash

--- a/easy-paging-postgres-demo/README.ko.md
+++ b/easy-paging-postgres-demo/README.ko.md
@@ -12,6 +12,28 @@
 - **Docker** (Docker Desktop 또는 호환 런타임)
 - 그 외 없음. 로컬 Postgres 설치 불필요. psql 클라이언트 불필요.
 
+## 이 데모만 받기
+
+각 데모는 독립 Gradle 프로젝트라, `devslab-examples` 저장소 전체를 clone하지 않고
+이 폴더만 받을 수 있습니다.
+
+**git 사용 (sparse checkout):**
+
+```bash
+git clone --filter=blob:none --sparse https://github.com/devslab-kr/devslab-examples.git
+cd devslab-examples
+git sparse-checkout set easy-paging-postgres-demo
+cd easy-paging-postgres-demo
+```
+
+**git 없이 (폴더만):**
+
+```bash
+curl -sL https://github.com/devslab-kr/devslab-examples/archive/refs/heads/main.tar.gz \
+  | tar -xz --strip-components=2 devslab-examples-main/easy-paging-postgres-demo
+cd easy-paging-postgres-demo
+```
+
 ## 실행
 
 ```bash

--- a/easy-paging-postgres-demo/README.md
+++ b/easy-paging-postgres-demo/README.md
@@ -12,6 +12,28 @@ The starter works on whatever JDBC database PageHelper supports (Postgres, MySQL
 - **Docker** (Docker Desktop or any Docker-compatible runtime)
 - That's it. No local Postgres install. No psql client needed.
 
+## Get just this demo
+
+Each demo is a standalone Gradle project, so you can grab this one folder without
+cloning the whole `devslab-examples` repo.
+
+**With git (sparse checkout):**
+
+```bash
+git clone --filter=blob:none --sparse https://github.com/devslab-kr/devslab-examples.git
+cd devslab-examples
+git sparse-checkout set easy-paging-postgres-demo
+cd easy-paging-postgres-demo
+```
+
+**Without git (folder only):**
+
+```bash
+curl -sL https://github.com/devslab-kr/devslab-examples/archive/refs/heads/main.tar.gz \
+  | tar -xz --strip-components=2 devslab-examples-main/easy-paging-postgres-demo
+cd easy-paging-postgres-demo
+```
+
 ## Run
 
 ```bash

--- a/easy-paging-reactive-demo/README.ko.md
+++ b/easy-paging-reactive-demo/README.ko.md
@@ -12,6 +12,28 @@ MVC + MyBatis 데모들 (`easy-paging-demo`, `easy-paging-postgres-demo`)은 AOP
 - **Docker** (`bootRun`과 `./gradlew test` 둘 다)
 - 로컬 Postgres 설치 불필요.
 
+## 이 데모만 받기
+
+각 데모는 독립 Gradle 프로젝트라, `devslab-examples` 저장소 전체를 clone하지 않고
+이 폴더만 받을 수 있습니다.
+
+**git 사용 (sparse checkout):**
+
+```bash
+git clone --filter=blob:none --sparse https://github.com/devslab-kr/devslab-examples.git
+cd devslab-examples
+git sparse-checkout set easy-paging-reactive-demo
+cd easy-paging-reactive-demo
+```
+
+**git 없이 (폴더만):**
+
+```bash
+curl -sL https://github.com/devslab-kr/devslab-examples/archive/refs/heads/main.tar.gz \
+  | tar -xz --strip-components=2 devslab-examples-main/easy-paging-reactive-demo
+cd easy-paging-reactive-demo
+```
+
 ## 실행
 
 ```bash

--- a/easy-paging-reactive-demo/README.md
+++ b/easy-paging-reactive-demo/README.md
@@ -12,6 +12,28 @@ The MVC + MyBatis demos (`easy-paging-demo`, `easy-paging-postgres-demo`) wire p
 - **Docker** (for both `bootRun` and `./gradlew test`)
 - No local Postgres install required.
 
+## Get just this demo
+
+Each demo is a standalone Gradle project, so you can grab this one folder without
+cloning the whole `devslab-examples` repo.
+
+**With git (sparse checkout):**
+
+```bash
+git clone --filter=blob:none --sparse https://github.com/devslab-kr/devslab-examples.git
+cd devslab-examples
+git sparse-checkout set easy-paging-reactive-demo
+cd easy-paging-reactive-demo
+```
+
+**Without git (folder only):**
+
+```bash
+curl -sL https://github.com/devslab-kr/devslab-examples/archive/refs/heads/main.tar.gz \
+  | tar -xz --strip-components=2 devslab-examples-main/easy-paging-reactive-demo
+cd easy-paging-reactive-demo
+```
+
 ## Run
 
 ```bash

--- a/easy-paging-sb4-demo/README.ko.md
+++ b/easy-paging-sb4-demo/README.ko.md
@@ -13,6 +13,28 @@
 - JDK 21+
 - 그 외 없음. H2는 인메모리, 의존성은 최초 빌드 시 다운로드됨.
 
+## 이 데모만 받기
+
+각 데모는 독립 Gradle 프로젝트라, `devslab-examples` 저장소 전체를 clone하지 않고
+이 폴더만 받을 수 있습니다.
+
+**git 사용 (sparse checkout):**
+
+```bash
+git clone --filter=blob:none --sparse https://github.com/devslab-kr/devslab-examples.git
+cd devslab-examples
+git sparse-checkout set easy-paging-sb4-demo
+cd easy-paging-sb4-demo
+```
+
+**git 없이 (폴더만):**
+
+```bash
+curl -sL https://github.com/devslab-kr/devslab-examples/archive/refs/heads/main.tar.gz \
+  | tar -xz --strip-components=2 devslab-examples-main/easy-paging-sb4-demo
+cd easy-paging-sb4-demo
+```
+
 ## 실행
 
 ```bash

--- a/easy-paging-sb4-demo/README.md
+++ b/easy-paging-sb4-demo/README.md
@@ -13,6 +13,28 @@ This demo wires the starter into a minimal Spring Boot app with an in-memory H2 
 - JDK 21+
 - Nothing else. H2 runs in-memory, dependencies download on first build.
 
+## Get just this demo
+
+Each demo is a standalone Gradle project, so you can grab this one folder without
+cloning the whole `devslab-examples` repo.
+
+**With git (sparse checkout):**
+
+```bash
+git clone --filter=blob:none --sparse https://github.com/devslab-kr/devslab-examples.git
+cd devslab-examples
+git sparse-checkout set easy-paging-sb4-demo
+cd easy-paging-sb4-demo
+```
+
+**Without git (folder only):**
+
+```bash
+curl -sL https://github.com/devslab-kr/devslab-examples/archive/refs/heads/main.tar.gz \
+  | tar -xz --strip-components=2 devslab-examples-main/easy-paging-sb4-demo
+cd easy-paging-sb4-demo
+```
+
 ## Run
 
 ```bash

--- a/easy-paging-sb4-keyset-demo/README.ko.md
+++ b/easy-paging-sb4-keyset-demo/README.ko.md
@@ -13,6 +13,28 @@
 - JDK 21+
 - 그 외 없음.
 
+## 이 데모만 받기
+
+각 데모는 독립 Gradle 프로젝트라, `devslab-examples` 저장소 전체를 clone하지 않고
+이 폴더만 받을 수 있습니다.
+
+**git 사용 (sparse checkout):**
+
+```bash
+git clone --filter=blob:none --sparse https://github.com/devslab-kr/devslab-examples.git
+cd devslab-examples
+git sparse-checkout set easy-paging-sb4-keyset-demo
+cd easy-paging-sb4-keyset-demo
+```
+
+**git 없이 (폴더만):**
+
+```bash
+curl -sL https://github.com/devslab-kr/devslab-examples/archive/refs/heads/main.tar.gz \
+  | tar -xz --strip-components=2 devslab-examples-main/easy-paging-sb4-keyset-demo
+cd easy-paging-sb4-keyset-demo
+```
+
 ## 실행
 
 ```bash

--- a/easy-paging-sb4-keyset-demo/README.md
+++ b/easy-paging-sb4-keyset-demo/README.md
@@ -13,6 +13,28 @@ Companion to [`easy-paging-demo`](../easy-paging-demo/) — which covers traditi
 - JDK 21+
 - Nothing else.
 
+## Get just this demo
+
+Each demo is a standalone Gradle project, so you can grab this one folder without
+cloning the whole `devslab-examples` repo.
+
+**With git (sparse checkout):**
+
+```bash
+git clone --filter=blob:none --sparse https://github.com/devslab-kr/devslab-examples.git
+cd devslab-examples
+git sparse-checkout set easy-paging-sb4-keyset-demo
+cd easy-paging-sb4-keyset-demo
+```
+
+**Without git (folder only):**
+
+```bash
+curl -sL https://github.com/devslab-kr/devslab-examples/archive/refs/heads/main.tar.gz \
+  | tar -xz --strip-components=2 devslab-examples-main/easy-paging-sb4-keyset-demo
+cd easy-paging-sb4-keyset-demo
+```
+
 ## Run
 
 ```bash

--- a/easy-paging-sb4-postgres-demo/README.ko.md
+++ b/easy-paging-sb4-postgres-demo/README.ko.md
@@ -14,6 +14,28 @@
 - **Docker** (Docker Desktop 또는 호환 런타임)
 - 그 외 없음. 로컬 Postgres 설치 불필요. psql 클라이언트 불필요.
 
+## 이 데모만 받기
+
+각 데모는 독립 Gradle 프로젝트라, `devslab-examples` 저장소 전체를 clone하지 않고
+이 폴더만 받을 수 있습니다.
+
+**git 사용 (sparse checkout):**
+
+```bash
+git clone --filter=blob:none --sparse https://github.com/devslab-kr/devslab-examples.git
+cd devslab-examples
+git sparse-checkout set easy-paging-sb4-postgres-demo
+cd easy-paging-sb4-postgres-demo
+```
+
+**git 없이 (폴더만):**
+
+```bash
+curl -sL https://github.com/devslab-kr/devslab-examples/archive/refs/heads/main.tar.gz \
+  | tar -xz --strip-components=2 devslab-examples-main/easy-paging-sb4-postgres-demo
+cd easy-paging-sb4-postgres-demo
+```
+
 ## 실행
 
 ```bash

--- a/easy-paging-sb4-postgres-demo/README.md
+++ b/easy-paging-sb4-postgres-demo/README.md
@@ -14,6 +14,28 @@ The starter works on whatever JDBC database PageHelper supports (Postgres, MySQL
 - **Docker** (Docker Desktop or any Docker-compatible runtime)
 - That's it. No local Postgres install. No psql client needed.
 
+## Get just this demo
+
+Each demo is a standalone Gradle project, so you can grab this one folder without
+cloning the whole `devslab-examples` repo.
+
+**With git (sparse checkout):**
+
+```bash
+git clone --filter=blob:none --sparse https://github.com/devslab-kr/devslab-examples.git
+cd devslab-examples
+git sparse-checkout set easy-paging-sb4-postgres-demo
+cd easy-paging-sb4-postgres-demo
+```
+
+**Without git (folder only):**
+
+```bash
+curl -sL https://github.com/devslab-kr/devslab-examples/archive/refs/heads/main.tar.gz \
+  | tar -xz --strip-components=2 devslab-examples-main/easy-paging-sb4-postgres-demo
+cd easy-paging-sb4-postgres-demo
+```
+
 ## Run
 
 ```bash

--- a/easy-paging-sb4-reactive-demo/README.ko.md
+++ b/easy-paging-sb4-reactive-demo/README.ko.md
@@ -14,6 +14,28 @@ MVC + MyBatis 데모들 (`easy-paging-demo`, `easy-paging-postgres-demo`)은 AOP
 - **Docker** (`bootRun`과 `./gradlew test` 둘 다)
 - 로컬 Postgres 설치 불필요.
 
+## 이 데모만 받기
+
+각 데모는 독립 Gradle 프로젝트라, `devslab-examples` 저장소 전체를 clone하지 않고
+이 폴더만 받을 수 있습니다.
+
+**git 사용 (sparse checkout):**
+
+```bash
+git clone --filter=blob:none --sparse https://github.com/devslab-kr/devslab-examples.git
+cd devslab-examples
+git sparse-checkout set easy-paging-sb4-reactive-demo
+cd easy-paging-sb4-reactive-demo
+```
+
+**git 없이 (폴더만):**
+
+```bash
+curl -sL https://github.com/devslab-kr/devslab-examples/archive/refs/heads/main.tar.gz \
+  | tar -xz --strip-components=2 devslab-examples-main/easy-paging-sb4-reactive-demo
+cd easy-paging-sb4-reactive-demo
+```
+
 ## 실행
 
 ```bash

--- a/easy-paging-sb4-reactive-demo/README.md
+++ b/easy-paging-sb4-reactive-demo/README.md
@@ -14,6 +14,28 @@ The MVC + MyBatis demos (`easy-paging-demo`, `easy-paging-postgres-demo`) wire p
 - **Docker** (for both `bootRun` and `./gradlew test`)
 - No local Postgres install required.
 
+## Get just this demo
+
+Each demo is a standalone Gradle project, so you can grab this one folder without
+cloning the whole `devslab-examples` repo.
+
+**With git (sparse checkout):**
+
+```bash
+git clone --filter=blob:none --sparse https://github.com/devslab-kr/devslab-examples.git
+cd devslab-examples
+git sparse-checkout set easy-paging-sb4-reactive-demo
+cd easy-paging-sb4-reactive-demo
+```
+
+**Without git (folder only):**
+
+```bash
+curl -sL https://github.com/devslab-kr/devslab-examples/archive/refs/heads/main.tar.gz \
+  | tar -xz --strip-components=2 devslab-examples-main/easy-paging-sb4-reactive-demo
+cd easy-paging-sb4-reactive-demo
+```
+
 ## Run
 
 ```bash

--- a/ssrf-guard-demo/README.ko.md
+++ b/ssrf-guard-demo/README.ko.md
@@ -17,6 +17,28 @@
 - JDK 21+
 - 인터넷 접근 가능한 화이트리스트 호스트 (`httpbin.org` 기본 — 허용 경로가 실제로 네트워크에 닿는 것을 보여주기 위함)
 
+## 이 데모만 받기
+
+각 데모는 독립 Gradle 프로젝트라, `devslab-examples` 저장소 전체를 clone하지 않고
+이 폴더만 받을 수 있습니다.
+
+**git 사용 (sparse checkout):**
+
+```bash
+git clone --filter=blob:none --sparse https://github.com/devslab-kr/devslab-examples.git
+cd devslab-examples
+git sparse-checkout set ssrf-guard-demo
+cd ssrf-guard-demo
+```
+
+**git 없이 (폴더만):**
+
+```bash
+curl -sL https://github.com/devslab-kr/devslab-examples/archive/refs/heads/main.tar.gz \
+  | tar -xz --strip-components=2 devslab-examples-main/ssrf-guard-demo
+cd ssrf-guard-demo
+```
+
 ## 실행
 
 ```bash

--- a/ssrf-guard-demo/README.md
+++ b/ssrf-guard-demo/README.md
@@ -17,6 +17,28 @@ Plus a `/attacks` endpoint that lists every SSRF bypass pattern the guard catche
 - JDK 21+
 - An internet-reachable host that's whitelisted (`httpbin.org` by default — used to show the allowed path actually reaches the network).
 
+## Get just this demo
+
+Each demo is a standalone Gradle project, so you can grab this one folder without
+cloning the whole `devslab-examples` repo.
+
+**With git (sparse checkout):**
+
+```bash
+git clone --filter=blob:none --sparse https://github.com/devslab-kr/devslab-examples.git
+cd devslab-examples
+git sparse-checkout set ssrf-guard-demo
+cd ssrf-guard-demo
+```
+
+**Without git (folder only):**
+
+```bash
+curl -sL https://github.com/devslab-kr/devslab-examples/archive/refs/heads/main.tar.gz \
+  | tar -xz --strip-components=2 devslab-examples-main/ssrf-guard-demo
+cd ssrf-guard-demo
+```
+
 ## Run
 
 ```bash

--- a/ssrf-guard-feign-demo/README.ko.md
+++ b/ssrf-guard-feign-demo/README.ko.md
@@ -8,6 +8,28 @@
 - `HttpBinClient` — `https://httpbin.org` 가리킴 (화이트리스트) — 호출 성공
 - `EvilClient` — `https://evil.com` 가리킴 (화이트리스트 밖) — Feign `RequestInterceptor`에서 차단됨, HTTP 트래픽이 JVM을 떠나지 않음
 
+## 이 데모만 받기
+
+각 데모는 독립 Gradle 프로젝트라, `devslab-examples` 저장소 전체를 clone하지 않고
+이 폴더만 받을 수 있습니다.
+
+**git 사용 (sparse checkout):**
+
+```bash
+git clone --filter=blob:none --sparse https://github.com/devslab-kr/devslab-examples.git
+cd devslab-examples
+git sparse-checkout set ssrf-guard-feign-demo
+cd ssrf-guard-feign-demo
+```
+
+**git 없이 (폴더만):**
+
+```bash
+curl -sL https://github.com/devslab-kr/devslab-examples/archive/refs/heads/main.tar.gz \
+  | tar -xz --strip-components=2 devslab-examples-main/ssrf-guard-feign-demo
+cd ssrf-guard-feign-demo
+```
+
 ## 실행
 
 ```bash

--- a/ssrf-guard-feign-demo/README.md
+++ b/ssrf-guard-feign-demo/README.md
@@ -8,6 +8,28 @@ Two declarative `@FeignClient` interfaces share one `UrlPolicy`:
 - `HttpBinClient` — points at `https://httpbin.org` (whitelisted) — calls succeed.
 - `EvilClient` — points at `https://evil.com` (not whitelisted) — calls blocked at the Feign `RequestInterceptor` before any HTTP traffic leaves the JVM.
 
+## Get just this demo
+
+Each demo is a standalone Gradle project, so you can grab this one folder without
+cloning the whole `devslab-examples` repo.
+
+**With git (sparse checkout):**
+
+```bash
+git clone --filter=blob:none --sparse https://github.com/devslab-kr/devslab-examples.git
+cd devslab-examples
+git sparse-checkout set ssrf-guard-feign-demo
+cd ssrf-guard-feign-demo
+```
+
+**Without git (folder only):**
+
+```bash
+curl -sL https://github.com/devslab-kr/devslab-examples/archive/refs/heads/main.tar.gz \
+  | tar -xz --strip-components=2 devslab-examples-main/ssrf-guard-feign-demo
+cd ssrf-guard-feign-demo
+```
+
 ## Run
 
 ```bash

--- a/ssrf-guard-httpclient5-demo/README.ko.md
+++ b/ssrf-guard-httpclient5-demo/README.ko.md
@@ -17,6 +17,28 @@
 
 `SafeDnsResolver`가 반환하는 `InetAddress[]`는 HttpClient가 `Socket.connect()`에 그대로 전달하는 배열 — 검증과 연결 사이에 두 번째 DNS 조회 없음. TOCTOU 윈도우가 거기서 닫힙니다.
 
+## 이 데모만 받기
+
+각 데모는 독립 Gradle 프로젝트라, `devslab-examples` 저장소 전체를 clone하지 않고
+이 폴더만 받을 수 있습니다.
+
+**git 사용 (sparse checkout):**
+
+```bash
+git clone --filter=blob:none --sparse https://github.com/devslab-kr/devslab-examples.git
+cd devslab-examples
+git sparse-checkout set ssrf-guard-httpclient5-demo
+cd ssrf-guard-httpclient5-demo
+```
+
+**git 없이 (폴더만):**
+
+```bash
+curl -sL https://github.com/devslab-kr/devslab-examples/archive/refs/heads/main.tar.gz \
+  | tar -xz --strip-components=2 devslab-examples-main/ssrf-guard-httpclient5-demo
+cd ssrf-guard-httpclient5-demo
+```
+
 ## 실행
 
 ```bash

--- a/ssrf-guard-httpclient5-demo/README.md
+++ b/ssrf-guard-httpclient5-demo/README.md
@@ -17,6 +17,28 @@ Two extension points on `HttpClients.custom()`:
 
 The `InetAddress[]` `SafeDnsResolver` returns is the exact same array HttpClient passes to `Socket.connect()` — so there's no second DNS lookup between validation and connection. That's the TOCTOU window closed.
 
+## Get just this demo
+
+Each demo is a standalone Gradle project, so you can grab this one folder without
+cloning the whole `devslab-examples` repo.
+
+**With git (sparse checkout):**
+
+```bash
+git clone --filter=blob:none --sparse https://github.com/devslab-kr/devslab-examples.git
+cd devslab-examples
+git sparse-checkout set ssrf-guard-httpclient5-demo
+cd ssrf-guard-httpclient5-demo
+```
+
+**Without git (folder only):**
+
+```bash
+curl -sL https://github.com/devslab-kr/devslab-examples/archive/refs/heads/main.tar.gz \
+  | tar -xz --strip-components=2 devslab-examples-main/ssrf-guard-httpclient5-demo
+cd ssrf-guard-httpclient5-demo
+```
+
 ## Run
 
 ```bash

--- a/ssrf-guard-jdkhttp-demo/README.ko.md
+++ b/ssrf-guard-jdkhttp-demo/README.ko.md
@@ -6,6 +6,28 @@
 
 **라이브러리 자체엔 Spring 필요 없음.** 이 데모는 REST 엔드포인트 노출을 위해서만 Spring Boot를 사용합니다. 실제 SSRF Guard wiring은 `SsrfGuardJdkHttpDemoApplication.java`의 3줄입니다.
 
+## 이 데모만 받기
+
+각 데모는 독립 Gradle 프로젝트라, `devslab-examples` 저장소 전체를 clone하지 않고
+이 폴더만 받을 수 있습니다.
+
+**git 사용 (sparse checkout):**
+
+```bash
+git clone --filter=blob:none --sparse https://github.com/devslab-kr/devslab-examples.git
+cd devslab-examples
+git sparse-checkout set ssrf-guard-jdkhttp-demo
+cd ssrf-guard-jdkhttp-demo
+```
+
+**git 없이 (폴더만):**
+
+```bash
+curl -sL https://github.com/devslab-kr/devslab-examples/archive/refs/heads/main.tar.gz \
+  | tar -xz --strip-components=2 devslab-examples-main/ssrf-guard-jdkhttp-demo
+cd ssrf-guard-jdkhttp-demo
+```
+
 ## 실행
 
 ```bash

--- a/ssrf-guard-jdkhttp-demo/README.md
+++ b/ssrf-guard-jdkhttp-demo/README.md
@@ -6,6 +6,28 @@ Runnable example for [`ssrf-guard-jdkhttp`](https://github.com/devslab-kr/ssrf-g
 
 **No Spring needed for the library itself.** This demo uses Spring Boot only to expose a REST endpoint for curl. The actual SSRF Guard wiring is three lines in `SsrfGuardJdkHttpDemoApplication.java`.
 
+## Get just this demo
+
+Each demo is a standalone Gradle project, so you can grab this one folder without
+cloning the whole `devslab-examples` repo.
+
+**With git (sparse checkout):**
+
+```bash
+git clone --filter=blob:none --sparse https://github.com/devslab-kr/devslab-examples.git
+cd devslab-examples
+git sparse-checkout set ssrf-guard-jdkhttp-demo
+cd ssrf-guard-jdkhttp-demo
+```
+
+**Without git (folder only):**
+
+```bash
+curl -sL https://github.com/devslab-kr/devslab-examples/archive/refs/heads/main.tar.gz \
+  | tar -xz --strip-components=2 devslab-examples-main/ssrf-guard-jdkhttp-demo
+cd ssrf-guard-jdkhttp-demo
+```
+
 ## Run
 
 ```bash

--- a/ssrf-guard-langchain4j-demo/README.ko.md
+++ b/ssrf-guard-langchain4j-demo/README.ko.md
@@ -26,6 +26,28 @@ URL이 공격자 컨트롤이면 **SSRF 한 줄**입니다. 공격자는 URL을 
 - JDK 21+
 - **LLM API 키 필요 없음** — 데모의 `FakeLlmService`가 실제 LLM 역할을 대신해서 오프라인 실행. 실제 `AiServices` 어시스턴트(`langchain4j-open-ai`, `langchain4j-anthropic` 등)로 바꿔도 보안 스토리는 동일.
 
+## 이 데모만 받기
+
+각 데모는 독립 Gradle 프로젝트라, `devslab-examples` 저장소 전체를 clone하지 않고
+이 폴더만 받을 수 있습니다.
+
+**git 사용 (sparse checkout):**
+
+```bash
+git clone --filter=blob:none --sparse https://github.com/devslab-kr/devslab-examples.git
+cd devslab-examples
+git sparse-checkout set ssrf-guard-langchain4j-demo
+cd ssrf-guard-langchain4j-demo
+```
+
+**git 없이 (폴더만):**
+
+```bash
+curl -sL https://github.com/devslab-kr/devslab-examples/archive/refs/heads/main.tar.gz \
+  | tar -xz --strip-components=2 devslab-examples-main/ssrf-guard-langchain4j-demo
+cd ssrf-guard-langchain4j-demo
+```
+
 ## 실행
 
 ```bash

--- a/ssrf-guard-langchain4j-demo/README.md
+++ b/ssrf-guard-langchain4j-demo/README.md
@@ -26,6 +26,28 @@ That's a one-line SSRF if the URL is attacker-controlled. The attacker doesn't e
 - JDK 21+
 - **No LLM API key required** — the demo's `FakeLlmService` stands in for a real LLM so the demo runs offline. Swap it for a real `AiServices`-built assistant (`langchain4j-open-ai`, `langchain4j-anthropic`, etc.) and the security story stays identical.
 
+## Get just this demo
+
+Each demo is a standalone Gradle project, so you can grab this one folder without
+cloning the whole `devslab-examples` repo.
+
+**With git (sparse checkout):**
+
+```bash
+git clone --filter=blob:none --sparse https://github.com/devslab-kr/devslab-examples.git
+cd devslab-examples
+git sparse-checkout set ssrf-guard-langchain4j-demo
+cd ssrf-guard-langchain4j-demo
+```
+
+**Without git (folder only):**
+
+```bash
+curl -sL https://github.com/devslab-kr/devslab-examples/archive/refs/heads/main.tar.gz \
+  | tar -xz --strip-components=2 devslab-examples-main/ssrf-guard-langchain4j-demo
+cd ssrf-guard-langchain4j-demo
+```
+
 ## Run
 
 ```bash

--- a/ssrf-guard-native-image-demo/README.ko.md
+++ b/ssrf-guard-native-image-demo/README.ko.md
@@ -29,6 +29,28 @@ ssrf-guard 3.1.0은 각 모듈에서 `META-INF/spring/aot.factories`로 `Runtime
 
 `GRAALVM_HOME` (또는 JDK가 GraalVM 디스트리이면 `JAVA_HOME`) 설정. `native-image --version`로 확인.
 
+## 이 데모만 받기
+
+각 데모는 독립 Gradle 프로젝트라, `devslab-examples` 저장소 전체를 clone하지 않고
+이 폴더만 받을 수 있습니다.
+
+**git 사용 (sparse checkout):**
+
+```bash
+git clone --filter=blob:none --sparse https://github.com/devslab-kr/devslab-examples.git
+cd devslab-examples
+git sparse-checkout set ssrf-guard-native-image-demo
+cd ssrf-guard-native-image-demo
+```
+
+**git 없이 (폴더만):**
+
+```bash
+curl -sL https://github.com/devslab-kr/devslab-examples/archive/refs/heads/main.tar.gz \
+  | tar -xz --strip-components=2 devslab-examples-main/ssrf-guard-native-image-demo
+cd ssrf-guard-native-image-demo
+```
+
 ## 일단 JVM에서 실행
 
 ```bash

--- a/ssrf-guard-native-image-demo/README.md
+++ b/ssrf-guard-native-image-demo/README.md
@@ -29,6 +29,28 @@ Without those hints, a native binary would fail at runtime with `MissingReflecti
 
 Set `GRAALVM_HOME` (or just `JAVA_HOME` if your JDK is a GraalVM distribution). Verify with `native-image --version`.
 
+## Get just this demo
+
+Each demo is a standalone Gradle project, so you can grab this one folder without
+cloning the whole `devslab-examples` repo.
+
+**With git (sparse checkout):**
+
+```bash
+git clone --filter=blob:none --sparse https://github.com/devslab-kr/devslab-examples.git
+cd devslab-examples
+git sparse-checkout set ssrf-guard-native-image-demo
+cd ssrf-guard-native-image-demo
+```
+
+**Without git (folder only):**
+
+```bash
+curl -sL https://github.com/devslab-kr/devslab-examples/archive/refs/heads/main.tar.gz \
+  | tar -xz --strip-components=2 devslab-examples-main/ssrf-guard-native-image-demo
+cd ssrf-guard-native-image-demo
+```
+
 ## Run it on the JVM first
 
 ```bash

--- a/ssrf-guard-okhttp-demo/README.ko.md
+++ b/ssrf-guard-okhttp-demo/README.ko.md
@@ -6,6 +6,28 @@
 
 **라이브러리 자체엔 Spring 필요 없음.** 데모가 Spring Boot로 감싸서 curl 친화적 엔드포인트를 제공하지만, 실제 통합은 `OkHttpClient.Builder` 3줄.
 
+## 이 데모만 받기
+
+각 데모는 독립 Gradle 프로젝트라, `devslab-examples` 저장소 전체를 clone하지 않고
+이 폴더만 받을 수 있습니다.
+
+**git 사용 (sparse checkout):**
+
+```bash
+git clone --filter=blob:none --sparse https://github.com/devslab-kr/devslab-examples.git
+cd devslab-examples
+git sparse-checkout set ssrf-guard-okhttp-demo
+cd ssrf-guard-okhttp-demo
+```
+
+**git 없이 (폴더만):**
+
+```bash
+curl -sL https://github.com/devslab-kr/devslab-examples/archive/refs/heads/main.tar.gz \
+  | tar -xz --strip-components=2 devslab-examples-main/ssrf-guard-okhttp-demo
+cd ssrf-guard-okhttp-demo
+```
+
 ## 실행
 
 ```bash

--- a/ssrf-guard-okhttp-demo/README.md
+++ b/ssrf-guard-okhttp-demo/README.md
@@ -6,6 +6,28 @@ Runnable example for [`ssrf-guard-okhttp`](https://github.com/devslab-kr/ssrf-gu
 
 **No Spring needed for the library itself.** The demo wraps Spring Boot around the wiring to give a curl-friendly endpoint, but the actual integration is three lines on `OkHttpClient.Builder`.
 
+## Get just this demo
+
+Each demo is a standalone Gradle project, so you can grab this one folder without
+cloning the whole `devslab-examples` repo.
+
+**With git (sparse checkout):**
+
+```bash
+git clone --filter=blob:none --sparse https://github.com/devslab-kr/devslab-examples.git
+cd devslab-examples
+git sparse-checkout set ssrf-guard-okhttp-demo
+cd ssrf-guard-okhttp-demo
+```
+
+**Without git (folder only):**
+
+```bash
+curl -sL https://github.com/devslab-kr/devslab-examples/archive/refs/heads/main.tar.gz \
+  | tar -xz --strip-components=2 devslab-examples-main/ssrf-guard-okhttp-demo
+cd ssrf-guard-okhttp-demo
+```
+
 ## Run
 
 ```bash

--- a/ssrf-guard-springai-demo/README.ko.md
+++ b/ssrf-guard-springai-demo/README.ko.md
@@ -21,6 +21,28 @@ URL이 공격자 컨트롤이면 **SSRF 한 줄**입니다. 공격자는 URL을 
 - JDK 21+
 - **LLM API 키 필요 없음** — 데모의 `FakeLlmService`가 실제 LLM 역할을 대신해서 오프라인 실행. `ChatClient` (Spring AI 1.0)로 바꿔도 보안 스토리는 동일.
 
+## 이 데모만 받기
+
+각 데모는 독립 Gradle 프로젝트라, `devslab-examples` 저장소 전체를 clone하지 않고
+이 폴더만 받을 수 있습니다.
+
+**git 사용 (sparse checkout):**
+
+```bash
+git clone --filter=blob:none --sparse https://github.com/devslab-kr/devslab-examples.git
+cd devslab-examples
+git sparse-checkout set ssrf-guard-springai-demo
+cd ssrf-guard-springai-demo
+```
+
+**git 없이 (폴더만):**
+
+```bash
+curl -sL https://github.com/devslab-kr/devslab-examples/archive/refs/heads/main.tar.gz \
+  | tar -xz --strip-components=2 devslab-examples-main/ssrf-guard-springai-demo
+cd ssrf-guard-springai-demo
+```
+
 ## 실행
 
 ```bash

--- a/ssrf-guard-springai-demo/README.md
+++ b/ssrf-guard-springai-demo/README.md
@@ -21,6 +21,28 @@ That's a one-line SSRF if the URL is attacker-controlled. The attacker doesn't e
 - JDK 21+
 - **No LLM API key required** — the demo's `FakeLlmService` stands in for a real LLM so the demo runs offline. Swap it for a `ChatClient` (Spring AI 1.0) and the security story stays identical.
 
+## Get just this demo
+
+Each demo is a standalone Gradle project, so you can grab this one folder without
+cloning the whole `devslab-examples` repo.
+
+**With git (sparse checkout):**
+
+```bash
+git clone --filter=blob:none --sparse https://github.com/devslab-kr/devslab-examples.git
+cd devslab-examples
+git sparse-checkout set ssrf-guard-springai-demo
+cd ssrf-guard-springai-demo
+```
+
+**Without git (folder only):**
+
+```bash
+curl -sL https://github.com/devslab-kr/devslab-examples/archive/refs/heads/main.tar.gz \
+  | tar -xz --strip-components=2 devslab-examples-main/ssrf-guard-springai-demo
+cd ssrf-guard-springai-demo
+```
+
 ## Run
 
 ```bash


### PR DESCRIPTION
## What / 무엇

Adds a **"Get just this demo"** section to every demo's README (`README.md` + `README.ko.md`, all 20 demos / 40 files), showing how to fetch a single demo folder instead of cloning the whole repo.

모든 데모 README(`README.md` + `README.ko.md`, 20개 데모 / 40파일)에 **"이 데모만 받기"** 섹션 추가 — 저장소 전체를 clone하지 않고 데모 한 폴더만 받는 방법.

## Why / 왜

Each demo is a standalone Gradle project (own `settings.gradle.kts` + `gradlew`), but the READMEs only documented cloning the entire `devslab-examples` repo. Readers who want one demo had no copy-paste path.

각 데모는 독립 Gradle 프로젝트인데, README는 전체 repo clone만 안내했음. 데모 하나만 원하는 사용자를 위한 복붙 경로가 없었음.

## How / 어떻게

Two methods per demo, parameterized to that demo's folder:

- **git sparse checkout** — `clone --filter=blob:none --sparse` then `git sparse-checkout set <demo>` (keeps history, downloads only that folder)
- **tarball (no git)** — `curl … main.tar.gz | tar -xz --strip-components=2 devslab-examples-main/<demo>` (folder only, no `.git`)

Placed right after **Prerequisites** (or just before the **Run** heading for the few demos without a Prerequisites section), so the flow reads *get → run*.

## Verification / 검증

- All 40 files contain the block; each references its **own** demo directory (verified by script — no cross-wired folder names).
- Docs-only change; no code touched.
