### PR TITLE
chore(devslab-kit-demo): bump devslab-kit starter to 0.4.0

### DIFF
--- a/devslab-kit-demo/build.gradle.kts
+++ b/devslab-kit-demo/build.gradle.kts
@@ -25,7 +25,7 @@ dependencies {
     // The devslab-kit starter pulls in the whole platform's auto-configuration —
     // including Swagger UI (springdoc is bundled from 0.2.1), so /swagger-ui and
     // /v3/api-docs come up with no extra dependency.
-    implementation("kr.devslab:devslab-kit-spring-boot-starter:0.3.0")
+    implementation("kr.devslab:devslab-kit-spring-boot-starter:0.4.0")
 
     // devslab-kit is deliberately unopinionated about which Spring starters you
     // bring — a consumer wires the runtime it actually wants. This is the set the


### PR DESCRIPTION
Bumps the `devslab-kit-demo` starter dependency `0.3.0` → `0.4.0` to track the [devslab-kit 0.4.0](https://github.com/devslab-kr/devslab-kit) release (config sync across environments).

⚠️ **Merge timing:** merge this only **after 0.4.0 is live on Maven Central** — the demo build resolves the starter from there, so merging earlier would red the demo build.

---

`devslab-kit-demo` 의 스타터 의존성을 `0.3.0` → `0.4.0` 으로 올립니다(devslab-kit 0.4.0, 환경 간 설정 동기화).

⚠️ **머지 시점:** **0.4.0 이 Maven Central 에 게시된 뒤** 머지하세요 — demo 빌드가 거기서 스타터를 받습니다.