### PR TITLE
chore(devslab-kit-demo): bump devslab-kit starter to 0.4.1

### DIFF
--- a/devslab-kit-demo/build.gradle.kts
+++ b/devslab-kit-demo/build.gradle.kts
@@ -25,7 +25,7 @@ dependencies {
     // The devslab-kit starter pulls in the whole platform's auto-configuration —
     // including Swagger UI (springdoc is bundled from 0.2.1), so /swagger-ui and
     // /v3/api-docs come up with no extra dependency.
-    implementation("kr.devslab:devslab-kit-spring-boot-starter:0.4.0")
+    implementation("kr.devslab:devslab-kit-spring-boot-starter:0.4.1")
 
     // devslab-kit is deliberately unopinionated about which Spring starters you
     // bring — a consumer wires the runtime it actually wants. This is the set the


### PR DESCRIPTION
Bumps the `devslab-kit-demo` starter dependency `0.4.0` → `0.4.1` (devslab-kit 0.4.1 — stable `PagedModel` for audit-log search). 0.4.1 is live on Maven Central, so the demo build resolves it.

---

`devslab-kit-demo` 스타터 의존성을 `0.4.0` → `0.4.1` 로 올립니다(devslab-kit 0.4.1, 감사 로그 PagedModel 패치). 0.4.1 Maven Central 게시 완료.