### PR TITLE
chore(devslab-kit-demo): bump devslab-kit starter to 0.4.2

### DIFF
--- a/devslab-kit-demo/build.gradle.kts
+++ b/devslab-kit-demo/build.gradle.kts
@@ -25,7 +25,7 @@ dependencies {
     // The devslab-kit starter pulls in the whole platform's auto-configuration —
     // including Swagger UI (springdoc is bundled from 0.2.1), so /swagger-ui and
     // /v3/api-docs come up with no extra dependency.
-    implementation("kr.devslab:devslab-kit-spring-boot-starter:0.4.1")
+    implementation("kr.devslab:devslab-kit-spring-boot-starter:0.4.2")
 
     // devslab-kit is deliberately unopinionated about which Spring starters you
     // bring — a consumer wires the runtime it actually wants. This is the set the


### PR DESCRIPTION
Bumps `devslab-kit-demo` `0.4.1` → `0.4.2` (user roles/groups list endpoints + cumulative PagedModel audit fix). 0.4.2 is live on Maven Central.

---

`devslab-kit-demo` 0.4.1 → 0.4.2 (사용자 역할/그룹 조회 엔드포인트 + PagedModel 누적 수정). 0.4.2 Maven Central 게시 완료.