### PR TITLE
chore: bump devslab-kit demo to 0.5.0

### DIFF
--- a/devslab-kit-demo/build.gradle.kts
+++ b/devslab-kit-demo/build.gradle.kts
@@ -25,7 +25,7 @@ dependencies {
     // The devslab-kit starter pulls in the whole platform's auto-configuration —
     // including Swagger UI (springdoc is bundled from 0.2.1), so /swagger-ui and
     // /v3/api-docs come up with no extra dependency.
-    implementation("kr.devslab:devslab-kit-spring-boot-starter:0.4.2")
+    implementation("kr.devslab:devslab-kit-spring-boot-starter:0.5.0")
 
     // devslab-kit is deliberately unopinionated about which Spring starters you
     // bring — a consumer wires the runtime it actually wants. This is the set the


### PR DESCRIPTION
Bumps the `devslab-kit-demo` dependency `kr.devslab:devslab-kit-spring-boot-starter` **0.4.2 → 0.5.0**.

devslab-kit 0.5.0 adds:
- **config-driven RBAC seed** (`devslab.kit.bootstrap.seed`) — declare permissions + roles, seeded idempotently on boot
- **JWT tenant resolver** — `resolver: jwt` resolves the tenant from the kit-issued bearer token's `tenant` claim

Demo builds green against 0.5.0 (`./gradlew build` BUILD SUCCESSFUL); 0.5.0 is synced to Maven Central.

(Release-checklist surface #6 for the devslab-kit 0.5.0 release.)